### PR TITLE
Fix TurnKey workout URL

### DIFF
--- a/src/lib/parse-turnkey-importer.js
+++ b/src/lib/parse-turnkey-importer.js
@@ -60,7 +60,7 @@ export function parseTurnKeyData(data) {
 
     let unitType = row[units_COL]; // Record the units type global for later. (we assume it won't change in the data)
 
-    const liftURL = `https://app.turnkey.coach//workout/${row[workout_id_COL]}`;
+    const liftURL = `https://app.turnkey.coach/workout/${row[workout_id_COL]}`;
 
     let liftType = row[exercise_name_COL];
 


### PR DESCRIPTION
## Summary
- fix parsing of TurnKey data by correcting workout URL

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420fcd6a6883319eede6e9eb3698d1