### PR TITLE
Last 24 hours git log

### DIFF
--- a/src/components/section-top-cards.js
+++ b/src/components/section-top-cards.js
@@ -680,8 +680,8 @@ function calculateSessionMomentum(parsedData) {
   const ninetyDaysAgoStr = subtractDaysFromStr(todayStr, 90);
   const oneEightyDaysAgoStr = subtractDaysFromStr(todayStr, 180);
 
-  let recentSessions = 0;
-  let previousSessions = 0;
+  const recentSessionDates = new Set();
+  const previousSessionDates = new Set();
 
   for (const entry of parsedData) {
     if (entry.isGoal) continue;
@@ -694,11 +694,14 @@ function calculateSessionMomentum(parsedData) {
 
     // YYYY-MM-DD string comparison
     if (dateStr >= ninetyDaysAgoStr && dateStr <= todayStr) {
-      recentSessions++;
+      recentSessionDates.add(dateStr);
     } else if (dateStr >= oneEightyDaysAgoStr && dateStr < ninetyDaysAgoStr) {
-      previousSessions++;
+      previousSessionDates.add(dateStr);
     }
   }
+
+  const recentSessions = recentSessionDates.size;
+  const previousSessions = previousSessionDates.size;
 
   let percentageChange = 0;
   if (previousSessions > 0) {


### PR DESCRIPTION
Fix Session Momentum calculation to count unique session days instead of individual lift rows.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e5b5ade0-44e2-4605-8c25-6c7d1c16ff41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5b5ade0-44e2-4605-8c25-6c7d1c16ff41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a UI metric calculation; main risk is user-visible count changes due to deduping sessions by date.
> 
> **Overview**
> Fixes the `Session Momentum` metric to count **unique training days** in each 90-day window rather than counting every lift row.
> 
> `calculateSessionMomentum` now accumulates distinct `YYYY-MM-DD` dates into Sets for the recent and previous 90-day periods, then uses the Set sizes to compute session counts and percentage change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11e4d58df056b59eefaed169e105010d7537dfd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->